### PR TITLE
CASMNET-772 -  Rename PowerDNS API key secret to match what is expected by external-dns chart

### DIFF
--- a/kubernetes/cray-dns-powerdns/values.yaml
+++ b/kubernetes/cray-dns-powerdns/values.yaml
@@ -45,7 +45,7 @@ cray-service:
           valueFrom:
             secretKeyRef:
               name: cray-powerdns-credentials
-              key: api_key
+              key: pdns_api_key
       ports:
         - name: pdns-server-udp
           containerPort: 53


### PR DESCRIPTION
The external-dns chart expects the key in the secret that holds the API key to be pdns_api_key