### PR TITLE
Allow container to run as root yet preserve priority class change

### DIFF
--- a/kubernetes/cray-dns-powerdns/values.yaml
+++ b/kubernetes/cray-dns-powerdns/values.yaml
@@ -15,6 +15,8 @@ cray-service:
   priorityClassName: "csm-high-priority-service"
   containers:
     - name: "cray-dns-powerdns"
+      securityContext:
+        runAsNonRoot: false
       image:
         repository: "cray/cray-dns-powerdns"
         pullPolicy: Always


### PR DESCRIPTION
Quick fix for 0.1.4 so it's not broken while I work on refactoring entrypoint.sh to support running as a non-root user.

This change has been tested on wasp, the stable version of 0.1.4 fails to start because the entrypoint script can no longer write to /etc. This change allows the container to start correctly.